### PR TITLE
Add details of Alces Cloud limits

### DIFF
--- a/docs/docs/compute/flavors.md
+++ b/docs/docs/compute/flavors.md
@@ -1,7 +1,7 @@
 #Flavors
 Alces Cloud instances are available in a number of flavors. The flavor chosen will define the resources available to your instance.
 
-Currently, there are four flavors available on Alces Cloud with the following sizes:
+Currently, there are two flavors available on Alces Cloud with the following sizes:
 
 | Flavor | VCPUs | RAM | Ephemeral Disk | Root Disk|
 |---|---|---|---|---|

--- a/docs/docs/compute/flavors.md
+++ b/docs/docs/compute/flavors.md
@@ -3,10 +3,13 @@ Alces Cloud instances are available in a number of flavors. The flavor chosen wi
 
 Currently, there are two flavors available on Alces Cloud with the following sizes:
 
-| Flavor | VCPUs | RAM | Ephemeral Disk | Root Disk|
-|---|---|---|---|---|
-| p1.small | 6 | 48 GB | 0 GB | 500 GB|
-| p1.large | 12 | 96 GB | 0 GB | 1000 GB|
+| Flavor | VCPUs | RAM | Ephemeral Disk | Root Disk | I/O Limit |
+|---|---|---|---|---|---|
+| p1.small | 6 | 48 GB | 0 GB | 500 GBi | 50 MB/s Read + Write |
+| p1.large | 12 | 96 GB | 0 GB | 1000 GB | 100 MB/s Read + Write |
+
+!!! info
+    I/O limits apply to instances booted using a local root disk. If you choose to boot your instance from a volume, the relevant volume limits will apply instead.
 
 You can also view these using the command line:
 

--- a/docs/docs/networking/networks.md
+++ b/docs/docs/networking/networks.md
@@ -2,6 +2,10 @@
 Alces Cloud provides you with the ability to create and manage your own private networks. This can be useful if you need to isolate an instances from other instances. Your project will come with a single network already configured, but additional networks can be created if required.
 
 Alces Cloud also provides an external network in order for you to access your instances. Instances cannot be connected directly to this network and instead floating IPs are allocated to your project and then associated to your instances.
+
+!!! info
+    The Alces Cloud external network is limited to 30MB/s per instance when using a floating IP. Instances without floating IPs will share a combined 30MB/s limit.
+
 === "CLI"
     ## Create a Network
     ```

--- a/docs/docs/storage/volumes.md
+++ b/docs/docs/storage/volumes.md
@@ -1,6 +1,12 @@
 #Volumes
 A volume acts as the virtual hard drive for your instances. All instances are required to be booted from a volume and additional volumes can be attached to your instances if you require additional disks.
 
+Available volume types:
+
+| Volume Type | I/O | IOPs |
+|---|---|---|
+| hdd.1 | 20 MB/s Read + Write | 60 IOPs Read + Write |
+
 === "CLI"
 
     ```


### PR DESCRIPTION
Adds details of Alces Cloud limits (disk I/O + network) to the relevant pages.